### PR TITLE
Add Logentries LogSet data source

### DIFF
--- a/logentries/data_source_logentries_logset.go
+++ b/logentries/data_source_logentries_logset.go
@@ -1,0 +1,27 @@
+package logentries
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceLogentriesLogSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceLogentriesLogSetRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"location": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "nonlocation",
+			},
+		},
+	}
+}
+
+func dataSourceLogentriesLogSetRead(d *schema.ResourceData, meta interface{}) error {
+	return resourceLogentriesLogSetRead(d, meta)
+}

--- a/logentries/data_source_logentries_logset_test.go
+++ b/logentries/data_source_logentries_logset_test.go
@@ -1,0 +1,58 @@
+package logentries
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	lexp "github.com/terraform-providers/terraform-provider-logentries/logentries/expect"
+)
+
+func TestAccDataSourceLogentriesLogSet(t *testing.T) {
+	var logSetResource LogSetResource
+
+	logSetName := fmt.Sprintf("terraform-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceLogentriesLogSet_basic(logSetName),
+				Check: lexp.TestCheckResourceExpectation(
+					"logentries_logset.logset",
+					&logSetResource,
+					testAccCheckLogentriesLogSetExists,
+					map[string]lexp.TestExpectValue{
+						"name": lexp.Equals(logSetName),
+					},
+				),
+			},
+			{
+				Config: testAccDataSourceLogentriesLogSet_basic(logSetName),
+				Check:  resource.TestCheckResourceAttr("data.logentries_logset.logset", "name", logSetName),
+			},
+		},
+	})
+}
+
+func testAccResourceLogentriesLogSet_basic(logSetName string) string {
+	return fmt.Sprintf(`
+resource "logentries_logset" "logset" {
+  name = "%s"
+}
+`, logSetName)
+}
+
+func testAccDataSourceLogentriesLogSet_basic(logSetName string) string {
+	return fmt.Sprintf(`
+resource "logentries_logset" "logset" {
+  name = "%s"
+}
+
+data "logentries_logset" "logset" {
+  name = "%s"
+}
+`, logSetName, logSetName)
+}

--- a/logentries/provider.go
+++ b/logentries/provider.go
@@ -19,7 +19,9 @@ func Provider() terraform.ResourceProvider {
 				Description: descriptions["account_key"],
 			},
 		},
-
+		DataSourcesMap: map[string]*schema.Resource{
+			"logentries_logset": dataSourceLogentriesLogSet(),
+		},
 		ResourcesMap: map[string]*schema.Resource{
 			"logentries_log":    resourceLogentriesLog(),
 			"logentries_logset": resourceLogentriesLogSet(),

--- a/logentries/resource_logentries_logset.go
+++ b/logentries/resource_logentries_logset.go
@@ -48,9 +48,12 @@ func resourceLogentriesLogSetCreate(d *schema.ResourceData, meta interface{}) er
 
 func resourceLogentriesLogSetRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*logentries.Client)
+
 	res, err := client.LogSet.Read(logentries.LogSetReadRequest{
-		Key: d.Id(),
+		Key:  d.Id(),
+		Name: d.Get("name").(string),
 	})
+
 	if err != nil {
 		if strings.Contains(err.Error(), "No such log set") {
 			log.Printf("Logentries LogSet Not Found - Refreshing from State")
@@ -65,7 +68,9 @@ func resourceLogentriesLogSetRead(d *schema.ResourceData, meta interface{}) erro
 		return nil
 	}
 
+	d.SetId(res.Key)
 	d.Set("location", res.Location)
+
 	return nil
 }
 

--- a/vendor/github.com/logentries/le_goclient/logset.go
+++ b/vendor/github.com/logentries/le_goclient/logset.go
@@ -57,7 +57,8 @@ func (l *LogSetClient) Create(createRequest LogSetCreateRequest) (*LogSet, error
 }
 
 type LogSetReadRequest struct {
-	Key string
+	Key  string
+	Name string
 }
 
 type LogSetReadResponse struct {
@@ -74,6 +75,8 @@ func (l *LogSetClient) Read(readRequest LogSetReadRequest) (*LogSet, error) {
 
 	for _, logSet := range response.LogSets {
 		if logSet.Key == readRequest.Key {
+			return &logSet, nil
+		} else if logSet.Name == readRequest.Name {
 			return &logSet, nil
 		}
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -523,10 +523,10 @@
 			"revisionTime": "2016-08-03T19:07:31Z"
 		},
 		{
-			"checksumSHA1": "KoB26db2df078Y2UClT7twI+dxg=",
+			"checksumSHA1": "eXY3j9R7m45X38ngqaDwnAfvoYQ=",
 			"path": "github.com/logentries/le_goclient",
-			"revision": "f6d02e2fca401d3550e08a292f54b0efb6a578f0",
-			"revisionTime": "2016-07-04T14:48:39Z"
+			"revision": "65841d26d18f4ccae5ee1ce6e7869a02a8ad0983",
+			"revisionTime": "2017-08-09T10:03:42Z"
 		},
 		{
 			"checksumSHA1": "guxbLo8KHHBeM0rzou4OTzzpDNs=",

--- a/website/docs/d/logentries_logset.html.markdown
+++ b/website/docs/d/logentries_logset.html.markdown
@@ -1,0 +1,27 @@
+---
+layout: "logentries"
+page_title: "Logentries: logentries_logset"
+sidebar_current: "docs-logentries-logentries_logset"
+description: |-
+  Get information on Logentries LogSet.
+---
+
+# logentries\_logset
+
+Use this data source to get information (like ID) of already existing Logentries LogSets.
+
+## Example Usage
+
+```hcl
+data "logentries_logset" "logset" {
+  name = "Example_Logset"
+}
+
+output "example_logset_id" {
+  value = "data.logentries_logset.logset.id"
+}
+```
+
+## Attributes Reference
+
+* `name` - Name of the LogSet to query.


### PR DESCRIPTION
We'd like to be able to refer to existing LogSets.

This is useful if you want to create a Log under already existing LogSet.  In order to do this, you need to provide LogSet ID to Logentries Log resource, but for existing LogSets there's no way to do
this without recreating LogSet (which we don't want).

This data source uses Logentries client library (I updated it recently to allow search for LogSets by name) to perform a search by name and return Terraform data source which you can refer to and query id and name.

Included tests and documentation.